### PR TITLE
Fix positional arguments for JiraApi

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -110,6 +110,7 @@ Bot.prototype.run = function () {
           value.jira.user,
           value.jira.password,
           value.jira.version,
+          value.jira.verbose,
           value.jira.strictSSL,
           value.jira.oauth
       );


### PR DESCRIPTION
JiraApi has different arguments order:
https://github.com/steves/node-jira/blob/master/lib/jira.js#L135
