### PR TITLE
Add ability to configure which issue fields are shown

### DIFF
--- a/config-example.js
+++ b/config-example.js
@@ -3,6 +3,7 @@ var slackbot = require('./lib/bot');
 var config = {
 
   showIssueDetails: true,
+  issueDetailsToShow: {'fields.summary':1 , 'fields.assignee' : 1, 'fields.description': 0},
   showDetailsByDefault: true,//if true, you don't need the '+' to get details
   bot_name: "jira",//Provide the name to post under
   token: 'XXXX-XXXXXXXXXX-XXXXXXXXXX-XXXXXXXXXX-XXXXXX', // https://api.slack.com/web

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -194,13 +194,16 @@ Bot.prototype.run = function () {
                       if (verbose) {
                         console.log(issue);
                       }
-                      if (issue.fields.assignee) {
+		      if (self.config.issueDetailsToShow['fields.assignee']   && issue.fields.assignee) {
                         msg += '\n*Assignee*: _' + issue.fields.assignee.displayName + '_';
-                      } else if (issue.fields.creator) {
+                      } else if (self.config.issueDetailsToShow['fields.creator'] && issue.fields.creator) {
                         msg += '\n*Creator*: _' + issue.fields.creator.displayName + '_';
                       }
-                      if (issue.fields.customfield_11041) {
+                      if (self.config.issueDetailsToShow['fields.developer'] && issue.fields.customfield_11041) {
                         msg += '\n*Developer*: _' + issue.fields.customfield_11041.displayName + '_';
+                      }
+                      if (self.config.issueDetailsToShow['fields.description'] && issue.fields.description) {
+                        msg += '\n*Description*: _' + issue.fields.description + '_';
                       }
                     }
                   } else {


### PR DESCRIPTION
I wanted to be able to configure which fields get shown. I added a config option to select among several issue fields to show.

 you can configure which fields are displayed in the config setting via the issueDetailsToShow hash, e.g.:

```
 issueDetailsToShow: {'fields.summary':1 , 'fields.assignee' : 1, 'fields.description': 0},
```

Here's a screenshot of the format I settled on:
<img width="676" alt="screen shot 2015-10-07 at 10 54 19 am" src="https://cloud.githubusercontent.com/assets/1385538/10341225/e3e85d78-6ce1-11e5-9a13-9e0c4d4dda19.png">
