### PR TITLE
Don't match XXX-0 (or XXX-01, etc.)

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -127,7 +127,7 @@ Bot.prototype.run = function () {
       prjNames += "|";
     }
   });
-  pattern += ")-\\d+)(\\+)?(?:(?=\\W)|$)";
+  pattern += ")-[1-9][0-9]*)(\\+)?(?:(?=\\W)|$)";
   if (verbose) {
     console.log("Pattern is: " + pattern);
   }


### PR DESCRIPTION
Jira doesn't recognize zero-padded issue numbers.