### PR TITLE
Make case insensitive

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -157,7 +157,7 @@ Bot.prototype.run = function () {
           // PROJECT-XXXX is the first capturing group, e.g. ((PROJECT)-\d+)
           var j = match[1].trim(),
           // PROJECT is the second capturing group
-              prjName = match[2],
+              prjName = match[2].toUpperCase(),
           // if the PROJECT-XXX is followed by a +, then we include
           // issue details in the response message:
               expandInfo = !!match[3];


### PR DESCRIPTION
Regex searches project key in message by case insensitive, but searching issue in jira uses plain 'prjName' that does not match when user uses lower case

Jira support only upper case project key
https://confluence.atlassian.com/adminjiraserver072/editing-a-project-key-828787721.html