### PR TITLE
Reject JIRA projects mentioned in URLs

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -95,7 +95,7 @@ Bot.prototype.run = function () {
   var self = this,
       verbose = self.config.verbose,
       bot = new slackbot(this.config.token),
-      pattern = "(?:\\W|^)((";
+      pattern = "(?:[^a-zA-Z0-9_/-]|^)((";
   var apis = {};
   _.each(self.config.jira_urls, function (value, key, obj) {
 


### PR DESCRIPTION
Change matching pattern to not trigger if project name was seen with a dash or slash prefixing it so pasting a URL into slack won't trigger it to be reposted.

We've been using this tweak at Roku without problem.